### PR TITLE
Update dune

### DIFF
--- a/ocaml/dune
+++ b/ocaml/dune
@@ -38,13 +38,13 @@
 
 (executable
  (name tokens)
- (libraries util cla benchmark readfile bytes tokenize)
+ (libraries util cla benchmark readfile tokenize)
  (modules tokens)
  (modes native))
 
 (executable
  (name wc_accum)
- (libraries util cla benchmark readfile bytes accumulate)
+ (libraries util cla benchmark readfile accumulate)
  (modules wc_accum)
  (modes native))
 


### PR DESCRIPTION
Having bytes in there gives a compilation error (shown below). It seems that removing it just works, probably because Ocaml has it? I don't understand it completely but the program runs

```
File "dune", line 47, characters 40-45:
47 |  (libraries util cla benchmark readfile bytes accumulate)
```