### PR TITLE
new block-based prime sieve benchmark

### DIFF
--- a/mpl/bench/primes-blocked/primes-blocked.mlb
+++ b/mpl/bench/primes-blocked/primes-blocked.mlb
@@ -1,0 +1,2 @@
+../../lib.mlb
+primes-blocked.sml

--- a/mpl/bench/primes-blocked/primes-blocked.sml
+++ b/mpl/bench/primes-blocked/primes-blocked.sml
@@ -1,0 +1,62 @@
+structure CLA = CommandLineArgs
+
+(* primes: int -> int array
+ * generate all primes up to (and including) n *)
+fun blockedPrimes n =
+  if n < 2 then
+    ForkJoin.alloc 0
+  else
+    let
+      val sqrtN = Real.floor (Math.sqrt (Real.fromInt n))
+      val sqrtPrimes = blockedPrimes sqrtN
+
+      val flags = ForkJoin.alloc (n + 1) : Word8.word array
+      fun mark i = Array.update (flags, i, 0w0)
+      fun unmark i = Array.update (flags, i, 0w1)
+      fun isMarked i =
+        Array.sub (flags, i) = 0w0
+      val _ = ForkJoin.parfor 10000 (0, n + 1) mark
+
+      val blockSize = Int.max (sqrtN, 1000)
+      val numBlocks = Util.ceilDiv (n + 1) blockSize
+
+      val _ = ForkJoin.parfor 1 (0, numBlocks) (fn b =>
+        let
+          val lo = b * blockSize
+          val hi = Int.min (lo + blockSize, n + 1)
+
+          fun loop i =
+            if i >= Array.length sqrtPrimes then
+              ()
+            else if 2 * Array.sub (sqrtPrimes, i) >= hi then
+              ()
+            else
+              let
+                val p = Array.sub (sqrtPrimes, i)
+                val lom = Int.max (2, Util.ceilDiv lo p)
+                val him = Util.ceilDiv hi p
+              in
+                Util.for (lom, him) (fn m => unmark (m * p));
+                loop (i + 1)
+              end
+        in
+          loop 0
+        end)
+    in
+      SeqBasis.filter 4096 (2, n + 1) (fn i => i) isMarked
+    end
+
+(* ==========================================================================
+ * parse command-line arguments and run
+ *)
+
+val n = CLA.parseInt "N" (100 * 1000 * 1000)
+
+val msg = "generating primes up to " ^ Int.toString n
+val result = Benchmark.run msg (fn _ => blockedPrimes n)
+
+val numPrimes = Array.length result
+val _ = print ("number of primes " ^ Int.toString numPrimes ^ "\n")
+val _ = print ("result " ^ Util.summarizeArray 8 Int.toString result ^ "\n")
+
+val _ = GCStats.report ()


### PR DESCRIPTION
New benchmark: `mpl/bench/primes-blocked/`

It uses a modified algorithm of the existing prime sieve. The new algorithm computes the sieve in a block-based manner, which has significantly better locality at the expense of a small loss in span.

The new algorithm is much faster (about 4x), although this could be partially due to compilation differences. (We've noticed in the past that the old primes algorithm seems to suffer from inefficient codegen.)

For the new algorithm, the high-level idea is: break the output of the sieve into blocks, and compute each block independently (in parallel across the blocks and sequentially within blocks). To compute a block, we loop through all primes up to `sqrt(n)` and mark multiples of those primes that fall within the block range.

Note that each block needs to loop through all primes up to `sqrt(n)`. If there were too many blocks, then the algorithm would not be work-efficient. So, to ensure work-efficiency, we use at most `sqrt(n)` blocks. (Technically it's possible to use more blocks, e.g. as many as `O(sqrt(n) * log(n))`, because there are `O(sqrt(n) / log(n))` primes less than `sqrt(n)`. But `sqrt(n)` blocks is plenty in terms of potential parallelism.)