### PR TITLE
`primes-segmented` benchmark

### DIFF
--- a/mpl/bench/primes-segmented/SegmentedPrimes.sml
+++ b/mpl/bench/primes-segmented/SegmentedPrimes.sml
@@ -1,0 +1,104 @@
+functor SegmentedPrimes
+  (I:
+   sig
+     type t
+     val from_int: int -> t
+     val to_int: t -> int
+   end):
+sig
+  val primes: int -> I.t Seq.t
+  val primes_with_params: {block_size_factor: real, report_times: bool}
+                          -> int
+                          -> I.t Seq.t
+end =
+struct
+
+  (* The block size used in the algorithm is approximately
+   *   sqrt(n)*block_size_factor
+   *
+   * Increasing block_size_factor will use larger blocks, which has all of the
+   * following effects on performance:
+   *   (1) decreased theoretical work
+   *   (2) less data locality (?)
+   *   (3) less parallelism
+   *)
+  fun primes_with_params (params as {block_size_factor, report_times}) n :
+    I.t Seq.t =
+    if n < 2 then
+      Seq.empty ()
+    else
+      let
+        val sqrt_n = Real.floor (Math.sqrt (Real.fromInt n))
+
+        val sqrt_primes = primes_with_params params sqrt_n
+
+        (* Split the range [2,n+1) into blocks *)
+        val block_size = Real.ceil (Real.fromInt sqrt_n * block_size_factor)
+        val block_size = Int.max (block_size, 1000)
+        val num_blocks = Util.ceilDiv ((n + 1) - 2) block_size
+
+        val (block_results, tm) = Util.getTime (fn _ =>
+          SeqBasis.reduce 1 TreeSeq.append (TreeSeq.empty ()) (0, num_blocks)
+            (fn b =>
+               let
+                 val lo = 2 + b * block_size
+                 val hi = Int.min (lo + block_size, n + 1)
+
+                 val flags = Array.array (hi - lo, 0w1 : Word8.word)
+                 fun unmark i =
+                   Array.update (flags, i - lo, 0w0)
+
+                 fun loop i =
+                   if i >= Seq.length sqrt_primes then
+                     ()
+                   else if 2 * I.to_int (Seq.nth sqrt_primes i) >= hi then
+                     ()
+                   else
+                     let
+                       val p = I.to_int (Seq.nth sqrt_primes i)
+                       val lom = Int.max (2, Util.ceilDiv lo p)
+                       val him = Util.ceilDiv hi p
+                     in
+                       Util.for (lom, him) (fn m => unmark (m * p));
+                       loop (i + 1)
+                     end
+
+                 val _ = loop 0
+
+                 val numPrimes = Util.loop (0, hi - lo) 0 (fn (count, i) =>
+                   if Array.sub (flags, i) = 0w0 then count else count + 1)
+
+                 val output = ForkJoin.alloc numPrimes
+
+                 val _ = Util.loop (lo, hi) 0 (fn (outi, i) =>
+                   if Array.sub (flags, i - lo) = 0w0 then outi
+                   else (Array.update (output, outi, I.from_int i); outi + 1))
+               in
+                 TreeSeq.from_array_seq (ArraySlice.full output)
+               end))
+
+        val _ =
+          if not report_times then
+            ()
+          else
+            print
+              ("sieve   (n = " ^ Int.toString n ^ "): " ^ Time.fmt 4 tm ^ "s\n")
+
+        val (result, tm) = Util.getTime (fn _ =>
+          TreeSeq.to_array_seq block_results)
+
+        val _ =
+          if not report_times then
+            ()
+          else
+            print
+              ("flatten (n = " ^ Int.toString n ^ "): " ^ Time.fmt 4 tm ^ "s\n")
+      in
+        result
+      end
+
+
+  fun primes n =
+    primes_with_params {block_size_factor = 8.0, report_times = false} n
+
+end

--- a/mpl/bench/primes-segmented/TreeSeq.sml
+++ b/mpl/bench/primes-segmented/TreeSeq.sml
@@ -1,0 +1,83 @@
+structure TreeSeq =
+struct
+  datatype 'a t =
+    Leaf
+  | Elem of 'a
+  | Flat of 'a Seq.t
+  | Node of {num_elems: int, num_blocks: int, left: 'a t, right: 'a t}
+
+  type 'a seq = 'a t
+
+  fun length Leaf = 0
+    | length (Elem _) = 1
+    | length (Flat s) = Seq.length s
+    | length (Node {num_elems = n, ...}) = n
+
+  fun num_blocks Leaf = 0
+    | num_blocks (Elem _) = 1
+    | num_blocks (Flat _) = 1
+    | num_blocks (Node {num_blocks = nb, ...}) = nb
+
+
+  fun append (t1, t2) =
+    Node
+      { num_elems = length t1 + length t2
+      , num_blocks = num_blocks t1 + num_blocks t2
+      , left = t1
+      , right = t2
+      }
+
+
+  fun to_blocks (t: 'a t) : 'a Seq.t Seq.t =
+    let
+      val blocks = ForkJoin.alloc (num_blocks t)
+
+      fun putBlocks offset t =
+        case t of
+          Leaf => ()
+        | Elem x => Array.update (blocks, offset, Seq.singleton x)
+        | Flat s => Array.update (blocks, offset, s)
+        | Node {num_blocks = nb, left = l, right = r, ...} =>
+            let
+              fun left () = putBlocks offset l
+              fun right () =
+                putBlocks (offset + num_blocks l) r
+            in
+              if nb <= 1000 then (left (); right ())
+              else (ForkJoin.par (left, right); ())
+            end
+    in
+      putBlocks 0 t;
+      ArraySlice.full blocks
+    end
+
+
+  fun to_array_seq t =
+    let
+      val a = ForkJoin.alloc (length t)
+      fun put offset t =
+        case t of
+          Leaf => ()
+        | Elem x => Array.update (a, offset, x)
+        | Flat s => Seq.foreach s (fn (i, x) => Array.update (a, offset + i, x))
+        | Node {num_elems = n, left = l, right = r, ...} =>
+            let
+              fun left () = put offset l
+              fun right () =
+                put (offset + length l) r
+            in
+              if n <= 4096 then (left (); right ())
+              else (ForkJoin.par (left, right); ())
+            end
+    in
+      put 0 t;
+      ArraySlice.full a
+    end
+
+  fun from_array_seq a = Flat a
+
+  fun empty () = Leaf
+  fun singleton x = Elem x
+  val $ = singleton
+
+end

--- a/mpl/bench/primes-segmented/main.sml
+++ b/mpl/bench/primes-segmented/main.sml
@@ -1,27 +1,64 @@
 structure CLA = CommandLineArgs
 
-structure I =
-struct
-  type t = Int64.int
-  val from_int = Int64.fromInt
-  val to_int = Int64.toInt
-  val to_string = Int64.toString
-end
-
-structure Primes = SegmentedPrimes(I)
-
 val n = CLA.parseInt "N" (100 * 1000 * 1000)
-val block_size_factor = CLA.parseReal "block-size-factor" 8.0
+val block_size_factor = CLA.parseReal "block-size-factor" 16.0
+val bits = CLA.parseInt "bits" 64
+val report_times = CLA.parseFlag "report-times"
+
 val _ = print ("N " ^ Int.toString n ^ "\n")
 val _ = print ("block-size-factor " ^ Real.toString block_size_factor ^ "\n")
+val _ = print ("bits " ^ Int.toString bits ^ "\n")
+val _ = print ("report-times? " ^ (if report_times then "yes" else "no") ^ "\n")
 
-val params = {block_size_factor = block_size_factor, report_times = true}
+functor Main
+  (I:
+   sig
+     type t
+     val from_int: int -> t
+     val to_int: t -> int
+     val to_string: t -> string
+   end) =
+struct
+  structure Primes = SegmentedPrimes(I)
 
-val msg = "generating primes up to " ^ Int.toString n
+  fun main () =
+    let
+      val params =
+        {block_size_factor = block_size_factor, report_times = report_times}
+      val msg = "generating primes up to " ^ Int.toString n
 
-val result = Benchmark.run msg (fn _ =>
-  Primes.primes_with_params params (I.from_int n))
+      val result = Benchmark.run msg (fn _ =>
+        Primes.primes_with_params params n)
 
-val numPrimes = Seq.length result
-val _ = print ("number of primes " ^ Int.toString numPrimes ^ "\n")
-val _ = print ("result " ^ Util.summarizeArraySlice 8 I.to_string result ^ "\n")
+      val numPrimes = Seq.length result
+      val _ = print ("number of primes " ^ Int.toString numPrimes ^ "\n")
+      val _ = print
+        ("result " ^ Util.summarizeArraySlice 8 I.to_string result ^ "\n")
+    in
+      ()
+    end
+end
+
+structure Main32 =
+  Main
+    (struct
+       type t = Int32.int
+       val from_int = Int32.fromInt
+       val to_int = Int32.toInt
+       val to_string = Int32.toString
+     end)
+
+structure Main64 =
+  Main
+    (struct
+       type t = Int64.int
+       val from_int = Int64.fromInt
+       val to_int = Int64.toInt
+       val to_string = Int64.toString
+     end)
+
+val _ =
+  case bits of
+    64 => Main64.main ()
+  | 32 => Main32.main ()
+  | _ => Util.die ("unknown -bits " ^ Int.toString bits ^ ": must be 32 or 64")

--- a/mpl/bench/primes-segmented/main.sml
+++ b/mpl/bench/primes-segmented/main.sml
@@ -1,0 +1,27 @@
+structure CLA = CommandLineArgs
+
+structure I =
+struct
+  type t = Int64.int
+  val from_int = Int64.fromInt
+  val to_int = Int64.toInt
+  val to_string = Int64.toString
+end
+
+structure Primes = SegmentedPrimes(I)
+
+val n = CLA.parseInt "N" (100 * 1000 * 1000)
+val block_size_factor = CLA.parseReal "block-size-factor" 8.0
+val _ = print ("N " ^ Int.toString n ^ "\n")
+val _ = print ("block-size-factor " ^ Real.toString block_size_factor ^ "\n")
+
+val params = {block_size_factor = block_size_factor, report_times = true}
+
+val msg = "generating primes up to " ^ Int.toString n
+
+val result = Benchmark.run msg (fn _ =>
+  Primes.primes_with_params params (I.from_int n))
+
+val numPrimes = Seq.length result
+val _ = print ("number of primes " ^ Int.toString numPrimes ^ "\n")
+val _ = print ("result " ^ Util.summarizeArraySlice 8 I.to_string result ^ "\n")

--- a/mpl/bench/primes-segmented/primes-segmented.mlb
+++ b/mpl/bench/primes-segmented/primes-segmented.mlb
@@ -1,0 +1,4 @@
+../../lib.mlb
+TreeSeq.sml
+SegmentedPrimes.sml
+main.sml


### PR DESCRIPTION
Just another fun benchmark; this is a follow-up to #4. Similar algorithm, but approximately 50% faster as `primes-blocked`. The key difference is that `primes-segmented` partially fuses the final filter phase with the sieve phase.