### PR TITLE
spork experiments: add `bignum-add-opt-ng` and switch to using `bignum-add-opt` and `bignum-add-opt-ng` for better perf comparison

### DIFF
--- a/mpl/bench/bignum-add-opt-ng/AddNG.sml
+++ b/mpl/bench/bignum-add-opt-ng/AddNG.sml
@@ -1,0 +1,87 @@
+structure AddNG =
+struct
+  structure Seq = ArraySequence
+
+  type byte = Word8.word
+  type bignum = byte Seq.t
+
+  fun init (b1, b2) =
+    Word8.+ (b1, b2)
+
+  fun copy (a, b) =
+    if b = 0w127 then a else b
+
+
+  fun add (x, y) =
+    let
+      val nx = Seq.length x
+      val ny = Seq.length y
+      val n = Int.max (nx, ny)
+
+      fun nthx i = if i < nx then Seq.nth x i else 0w0
+      fun nthy i = if i < ny then Seq.nth y i else 0w0
+
+      (* This algorithm is essentially a fused map-scan-map (or perhaps more
+       * accurately map-scan-zip). See for example ../bignum-add/MkAdd.sml.
+       * We could attempt to do fusion automatically, but this doesn't appear
+       * to be performing very well at the moment (perhaps due to poor inlining
+       * heuristics in the compiler). So here we manually perform the fusion
+       * ourselves. The structure of this code is nearly identical to the code
+       * for SeqBasisNG.scan, but we've incorporated the fused operations.
+       *)
+      val blockSize = Grains.block
+      val numBlocks = 1 + ((n-1) div blockSize)
+
+      val blockCarries =
+        SeqBasisNG.tabulate (0, numBlocks) (fn blockIdx =>
+          let
+            val lo = blockIdx * blockSize
+            val hi = Int.min (lo + blockSize, n)
+            (* fun loop acc i =
+              if i >= hi then
+                acc
+              else
+                loop (copy (acc, init (nthx i, nthy i))) (i+1) *)
+          in
+            (* loop 0w0 lo *)
+            SeqBasisNG.reduce copy 0w0 (lo, hi) (fn i => init (nthx i, nthy i))
+          end)
+
+      val blockPartials =
+        SeqBasisNG.scan copy 0w0 (0, numBlocks)
+        (fn i => Array.sub (blockCarries, i))
+
+      val lastCarry = Array.sub (blockPartials, numBlocks)
+
+      val result = ForkJoin.alloc (n+1)
+
+      val _ =
+        ForkJoinNG.parfor (0, numBlocks) (fn blockIdx =>
+          let
+            val lo = blockIdx * blockSize
+            val hi = Int.min (lo + blockSize, n)
+
+            fun loop acc i =
+              if i >= hi then
+                ()
+              else
+                let
+                  val sum = init (nthx i, nthy i)
+                  val acc' = copy (acc, sum)
+                  val thisByte =
+                    Word8.andb (Word8.+ (Word8.>> (acc, 0w7), sum), 0wx7F)
+                in
+                  Array.update (result, i, thisByte);
+                  loop acc' (i+1)
+                end
+          in
+            loop (Array.sub (blockPartials, blockIdx)) lo
+          end)
+
+    in
+      if lastCarry > 0w127 then
+        (Array.update (result, n, 0w1); ArraySlice.full result)
+      else
+        (ArraySlice.slice (result, 0, SOME n))
+    end
+end

--- a/mpl/bench/bignum-add-opt-ng/AddNG.sml
+++ b/mpl/bench/bignum-add-opt-ng/AddNG.sml
@@ -43,12 +43,12 @@ struct
               else
                 loop (copy (acc, init (nthx i, nthy i))) (i+1) *)
           in
-            (* loop 0w0 lo *)
-            SeqBasisNG.reduce copy 0w0 (lo, hi) (fn i => init (nthx i, nthy i))
+            (* loop 0w127 lo *)
+            SeqBasisNG.reduce copy 0w127 (lo, hi) (fn i => init (nthx i, nthy i))
           end)
 
       val blockPartials =
-        SeqBasisNG.scan copy 0w0 (0, numBlocks)
+        SeqBasisNG.scan copy 0w127 (0, numBlocks)
         (fn i => Array.sub (blockCarries, i))
 
       val lastCarry = Array.sub (blockPartials, numBlocks)

--- a/mpl/bench/bignum-add-opt-ng/bignum-add-opt-ng.mlb
+++ b/mpl/bench/bignum-add-opt-ng/bignum-add-opt-ng.mlb
@@ -1,0 +1,6 @@
+../../lib.mlb
+../bignum-add/Bignum.sml
+(* ../bignum-add/MkAdd.sml *)
+../bignum-add/SequentialAdd.sml
+AddNG.sml
+main.sml

--- a/mpl/bench/bignum-add-opt-ng/main.sml
+++ b/mpl/bench/bignum-add-opt-ng/main.sml
@@ -1,0 +1,34 @@
+structure CLA = CommandLineArgs
+structure Seq = SeqNG
+
+(* structure Add = MkAdd(OldDelayedSeqNG) *)
+structure Add = AddNG
+
+val n = CLA.parseInt "n" (1000 * 1000 * 100)
+val seed = CLA.parseInt "seed" 15210
+val doCheck = CLA.parseFlag "check"
+
+val _ = print ("n " ^ Int.toString n ^ "\n")
+
+val input1 = Bignum.generate n seed
+val input2 = Bignum.generate n (seed + n)
+
+fun task () = Add.add (input1, input2)
+
+fun check result =
+  if not doCheck then
+    ()
+  else
+    let
+      val (correctResult, tm) = Util.getTime (fn _ =>
+        SequentialAdd.add (input1, input2))
+      val _ = print ("sequential " ^ Time.fmt 4 tm ^ "s\n")
+      val correct = Seq.equal op= (result, correctResult)
+    in
+      if correct then print ("correct? yes\n") else print ("correct? no\n")
+    end
+
+val result = Benchmark.run "bignum add" task
+val _ =
+  check
+    result (* val _ = print ("result " ^ IntInf.toString (Bignum.toIntInf result) ^ "\n") *)

--- a/mpl/bench/bignum-add-opt/Add.sml
+++ b/mpl/bench/bignum-add-opt/Add.sml
@@ -35,11 +35,11 @@ struct
               else
                 loop (copy (acc, init (nthx i, nthy i))) (i+1)
           in
-            loop 0w0 lo
+            loop 0w127 lo
           end)
 
       val blockPartials =
-        SeqBasis.scan 5000 copy 0w0 (0, numBlocks)
+        SeqBasis.scan 5000 copy 0w127 (0, numBlocks)
         (fn i => Array.sub (blockCarries, i))
 
       val lastCarry = Array.sub (blockPartials, numBlocks)

--- a/mpl/bench/bignum-add/MkAdd.sml
+++ b/mpl/bench/bignum-add/MkAdd.sml
@@ -19,7 +19,7 @@ struct
 
       fun propagate (a, b) =
         if b = 0w127 then a else b
-      val (carries, _) = Seq.scan propagate 0w0 sums
+      val (carries, _) = Seq.scan propagate 0w127 sums
 
       fun f (carry, sum) =
         Word8.andb (Word8.+ (Word8.>> (carry, 0w7), sum), 0wx7F)

--- a/spork-exp-hb.json
+++ b/spork-exp-hb.json
@@ -208,11 +208,11 @@
      "args": ["EE ../inputs/words256-shuffled.txt --benchmark"]},
 
     {"tag": ["bignum-add"],
-     "bench": ["bignum-add"],
+     "bench": ["bignum-add-opt"],
      "args": ["-n 100000000"]},
 
     {"tag": ["bignum-add-ng"],
-     "bench": ["bignum-add-ng"],
+     "bench": ["bignum-add-opt-ng"],
      "args": ["-n 100000000"]},
 
     {"tag": ["suffix-array"],


### PR DESCRIPTION
@colin-mcd this fixes the bignum perf discrepancy by avoiding any compilation/optimization issues with delayed seq. Now, as expected, the manually tuned version performs better.

The bignum algorithm is essentially just one big fused map-scan-map (or perhaps more accurately map-scan-zip). The implementation of `bignum-add-opt` was derived by manually inlining these operations and then optimizing by eliminating intermediate allocations. The implementation of `bignum-add-opt-ng` is very similar; the structure of the code is nearly identical to `SeqBasisNG.scan` but with the additional fused operations.

I also found a small bug and fixed it. This doesn't have any impact on performance.